### PR TITLE
Fix the way '+' is handled in S3 pairtrees

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <freelib.utils.version>0.8.8</freelib.utils.version>
     <codacy.plugin.version>1.0.2</codacy.plugin.version>
     <aws.sdk.version>1.11.22</aws.sdk.version>
-    <vertx.version>3.5.1</vertx.version>
+    <vertx.version>3.5.4</vertx.version>
     <jackson.version>2.9.5</jackson.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <artifactId>vertx-pairtree</artifactId>
   <packaging>jar</packaging>
-  <version>0.0.4-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Vert.x Pairtree</name>
   <description>A Pairtree library for Vert.x</description>
   <url>http://projects.freelibrary.info/vertx-pairtree</url>

--- a/src/test/java/info/freelibrary/pairtree/s3/AbstractS3IT.java
+++ b/src/test/java/info/freelibrary/pairtree/s3/AbstractS3IT.java
@@ -105,8 +105,10 @@ public abstract class AbstractS3IT extends AbstractPairtreeTest {
         final Iterator<S3ObjectSummary> iterator = listing.getObjectSummaries().iterator();
 
         while (iterator.hasNext()) {
+            final String key = iterator.next().getKey();
+
             try {
-                myS3Client.deleteObject(myTestBucket, iterator.next().getKey());
+                myS3Client.deleteObject(myTestBucket, key);
             } catch (final AmazonClientException details) {
                 aContext.fail(details);
             }

--- a/src/test/java/info/freelibrary/pairtree/s3/S3PairtreeObjectIT.java
+++ b/src/test/java/info/freelibrary/pairtree/s3/S3PairtreeObjectIT.java
@@ -39,7 +39,7 @@ public class S3PairtreeObjectIT extends AbstractS3IT {
     private static final String GREEN_GIF = "a/b/green.gif";
 
     /** A path for a secondary test object */
-    private static final String GREEN_BLUE_GIF = "green~blue.gif";
+    private static final String GREEN_BLUE_GIF = "green+blue.gif";
 
     /** The Pairtree being tested */
     private PairtreeRoot myPairtree;
@@ -109,13 +109,13 @@ public class S3PairtreeObjectIT extends AbstractS3IT {
 
         myPairtree.getObject("ark:/99999/88888888").create(result -> {
             if (result.succeeded()) {
-                final String ptPath = PairtreeUtils.mapToPtPath("ark:/99999/88888888").replace('+', '~');
+                final String ptPath = PairtreeUtils.mapToPtPath("ark:/99999/88888888");
                 final StringJoiner objectPath = new StringJoiner("/");
 
-                objectPath.add(PAIRTREE_ROOT).add(ptPath).add("ark~=99999=88888888/README.txt");
+                objectPath.add(PAIRTREE_ROOT).add(ptPath).add("ark+=99999=88888888/README.txt");
 
                 if (!myS3Client.doesObjectExist(myTestBucket, objectPath.toString())) {
-                    aContext.fail(MessageCodes.PT_DEBUG_050);
+                    aContext.fail(getI18n(MessageCodes.PT_DEBUG_050));
                 }
             } else {
                 aContext.fail(result.cause());
@@ -166,7 +166,11 @@ public class S3PairtreeObjectIT extends AbstractS3IT {
 
     @Test
     public final void testGetPathStringWithPlus(final TestContext aContext) {
-        aContext.assertEquals(myS3Path + "/" + GREEN_BLUE_GIF, myPairtree.getObject(myUID).getPath(GREEN_BLUE_GIF));
+        // The S3 path has a URL encoded '+' because of this S3 bug that will probably never be fixed:
+        // https://forums.aws.amazon.com/thread.jspa?threadID=55746
+        // It appears normal in S3 or in the resource name once it's copied down to a file system
+        aContext.assertEquals(myS3Path + "/" + GREEN_BLUE_GIF, myPairtree.getObject(myUID).getPath(GREEN_BLUE_GIF)
+                .replace("%2B", "+"));
     }
 
     @Test
@@ -188,8 +192,8 @@ public class S3PairtreeObjectIT extends AbstractS3IT {
 
         myPairtree.getObject(myUID).put("ark+=99999=99999999.gif", Buffer.buffer(myResource), result -> {
             if (result.succeeded()) {
-                if (!myS3Client.doesObjectExist(myTestBucket, myS3Path + "/ark~=99999=99999999.gif")) {
-                    aContext.fail(MessageCodes.PT_DEBUG_051);
+                if (!myS3Client.doesObjectExist(myTestBucket, myS3Path + "/ark+=99999=99999999.gif")) {
+                    aContext.fail(getI18n(MessageCodes.PT_DEBUG_051));
                 }
             } else {
                 aContext.fail(result.cause());


### PR DESCRIPTION
This is a breaking change with the previous pairtree structure on S3 so version number is bumped.